### PR TITLE
Allow column identifiers like TABLE.family.cell, which are valid in A…

### DIFF
--- a/src/D2L.SQL.Validation/Language/SqlGrammar.cs
+++ b/src/D2L.SQL.Validation/Language/SqlGrammar.cs
@@ -193,7 +193,7 @@ namespace D2L.SQL.Language {
 			conditionRhsOpt.Rule = Empty | comparisonOperator + operand | IS + ( Empty | NOT ) + NULL | inClause | betweenClause; // TODO: rhs operand not operand
 			operand.Rule = value | column | function;
 			value.Rule = string_literal | number;
-			column.Rule = Id;
+			column.Rule = MakePlusRule( column, dot, Id );
 
 			comparisonOperator.Rule = EQ | LT | GT | LTE | GTE | NEQ1 | NEQ2 | LIKE;
 

--- a/test/D2L.SQL.UnitTests/ValidatorTests.cs
+++ b/test/D2L.SQL.UnitTests/ValidatorTests.cs
@@ -71,6 +71,7 @@ namespace D2L.SQL.UnitTests {
 		[TestCase( "SELECT COUNT(*) FROM TEST_WEB_STAT WHERE HOST = 'SYSTEM'" )]
 		[TestCase( "SELECT mt.HOST, nmt.HOST, mt.DOMAIN, nmt.DOMAIN FROM TEST_WEB_STAT_MULTI_TENANT mt INNER JOIN TEST_WEB_STAT nmt ON (mt.HOST = nmt.HOST) LIMIT 1" )]
 		[TestCase( "SELECT mt.HOST, nmt.HOST, mt.DOMAIN, nmt.DOMAIN FROM TEST_WEB_STAT_MULTI_TENANT mt, TEST_WEB_STAT nmt WHERE mt.HOST = nmt.HOST LIMIT 1" )]
+		[TestCase( "SELECT NAME.ALPHA, NAME.BETA, SOME_UIDS.ALPHA, SOME_UIDS.BETA, SOME_UIDS.NAME.TENANT, NAME.INTERACTIONTYPE FROM SOME_UIDS SOME_UIDS LIMIT 20" )]
 		public void SanitizeReturnsInput_GivenValidSql( string sql ) {
 			// The interface doesn't actually guarantee that the output equals the input, but this is the easiest test given the current implementation
 			Assert.That( m_validator.Sanitize( sql ), Is.EqualTo( sql ) );


### PR DESCRIPTION
…pache Phoenix

Some Excel-generated odbc queries are currently breaking because they have this form.

@mtseD2L @j3parker 